### PR TITLE
Bug fix for searchFileCollection on railo on windows

### DIFF
--- a/lib/searchService.cfc
+++ b/lib/searchService.cfc
@@ -480,7 +480,7 @@
 	
 	<cfloop query="rsRaw">
 		<cfset queryAddRow(rsResult,1)/>
-		<cfset querysetcell(rsResult,"fileID",listLast(listFirst(rsRaw.url,"."),"/"),rsRaw.currentRow)/>
+		<cfset querysetcell(rsResult,"fileID",listLast(listFirst(rsRaw.url,"."),"\/"),rsRaw.currentRow)/>
 		<cfset querysetcell(rsResult,"score",rsRaw.score,rsRaw.currentRow)/>
 		<cfset querysetcell(rsResult,"context",rsRaw.context,rsRaw.currentRow)/>
 		


### PR DESCRIPTION
Hi Matt, 

Ran into a bug running on railo 4 on windows, after a reindex file urls returned by lucene were changing from /fileID.fileExt to \fileID.fileExt (forward slash turning to back slash) which was causing the searchFileCollection method to parse out incorrect fileIDs which was hiding matched files from the search results. I've updated searchFileCollection() to parse out the correct fileID now and I'm seeing files appearing in my search results correctly.
